### PR TITLE
Fix PHP Notice "Only variables ... by reference" in DefaultAssocLangModel.php on line 70

### DIFF
--- a/administrator/components/com_associations/Model/DefaultAssocLangModel.php
+++ b/administrator/components/com_associations/Model/DefaultAssocLangModel.php
@@ -56,7 +56,7 @@ class DefaultAssocLangModel extends BaseModel
 			->bind(':id', $parentId, ParameterType::INTEGER)
 			->bind(':context', $context);
 		$parentModified = $db->setQuery($subQuery)->loadResult();
-		$parentModifiedSql = Factory::getDate($parentModified)->toSql()
+		$parentModifiedSql = Factory::getDate($parentModified)->toSql();
 
 		$query = $db->getQuery(true)
 			->update($db->quoteName('#__associations'))

--- a/administrator/components/com_associations/Model/DefaultAssocLangModel.php
+++ b/administrator/components/com_associations/Model/DefaultAssocLangModel.php
@@ -56,6 +56,7 @@ class DefaultAssocLangModel extends BaseModel
 			->bind(':id', $parentId, ParameterType::INTEGER)
 			->bind(':context', $context);
 		$parentModified = $db->setQuery($subQuery)->loadResult();
+		$parentModifiedSql = Factory::getDate($parentModified)->toSql()
 
 		$query = $db->getQuery(true)
 			->update($db->quoteName('#__associations'))
@@ -67,7 +68,7 @@ class DefaultAssocLangModel extends BaseModel
 					$db->quoteName('context') . ' = :context'
 				]
 			)
-			->bind(':parent_date', $parentModified = Factory::getDate($parentModified)->toSql())
+			->bind(':parent_date', $parentModifiedSql)
 			->bind(':id', $childId, ParameterType::INTEGER)
 			->bind(':parent_id', $parentId, ParameterType::INTEGER)
 			->bind(':context', $context);


### PR DESCRIPTION
Fix PHP Notice "Only variables should be passed by reference" in /administrator/components/com_associations/Model/DefaultAssocLangModel.php on line 70
